### PR TITLE
Upgrade crate imgui 0.0.21

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ license = "MIT/Apache-2.0"
 travis-ci = { repository = "michaelfairley/rust-imgui-opengl-renderer" }
 
 [dependencies]
-imgui = "0.0.20"
+imgui = "0.0.21"
 
 [build-dependencies]
 gl_generator = "0.9.0"


### PR DESCRIPTION
I wonder if there's a way not to be forced to do this every new version... Maybe specifying "*"?