### PR TITLE
Fix support for high-dpi displays

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -231,10 +231,10 @@ impl Renderer {
             } => {
               gl.BindTexture(gl::TEXTURE_2D, texture_id.id() as _);
 
-              gl.Scissor(x as GLint,
-                         (fb_height - w) as GLint,
-                         (z - x) as GLint,
-                         (w - y) as GLint);
+              gl.Scissor((x * scale_w) as GLint,
+                         (fb_height - w * scale_h) as GLint,
+                         ((z - x) * scale_w) as GLint,
+                         ((w - y) * scale_h) as GLint);
 
               let idx_size = if mem::size_of::<DrawIdx>() == 2 { gl::UNSIGNED_SHORT } else { gl::UNSIGNED_INT };
 


### PR DESCRIPTION
Hi!

imgui rendering is currently broken on high-dpi displays where `display_framebuffer_scale != [1.0, 1.0]`. The framebuffer width and height are computed properly, but the scissor boundaries do not take the framebuffer scale into account.

Before:
![image](https://user-images.githubusercontent.com/1621758/68934827-b9fc5780-0797-11ea-89c3-6e37892aeeef.png)

After:
![image](https://user-images.githubusercontent.com/1621758/68934868-ced8eb00-0797-11ea-82b2-ba6d613c3619.png)
