### PR TITLE
Bump imgui-rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["gui", "rendering::graphics-api"]
 license = "MIT/Apache-2.0"
 
 [dependencies]
-imgui = ">=0.7.0, <0.9.0"
+imgui = "0.9.0"
 
 [build-dependencies]
 gl_generator = "0.14.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 extern crate imgui;
 
-use imgui::{Context,Ui};
+use imgui::Context;
 use std::mem;
 
 mod gl {
@@ -137,7 +137,6 @@ impl Renderer {
 
   pub fn render(
     &self,
-    ui: &mut Ui,
     ctx: &mut Context,
   ) {
     use imgui::{DrawVert,DrawIdx,DrawCmd,DrawCmdParams};
@@ -177,8 +176,8 @@ impl Renderer {
       gl.PolygonMode(gl::FRONT_AND_BACK, gl::FILL);
 
 
-      let [width, height] = ui.io().display_size;
-      let [scale_w, scale_h] = ui.io().display_framebuffer_scale;
+      let [width, height] = ctx.io().display_size;
+      let [scale_w, scale_h] = ctx.io().display_framebuffer_scale;
 
       let fb_width = width * scale_w;
       let fb_height = height * scale_h;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,7 +137,7 @@ impl Renderer {
 
   pub fn render(
     &self,
-    ui: Ui,
+    ui: &mut Ui,
     ctx: &mut Context,
   ) {
     use imgui::{DrawVert,DrawIdx,DrawCmd,DrawCmdParams};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,9 +135,10 @@ impl Renderer {
     }
   }
 
-  pub fn render<'ui>(
+  pub fn render(
     &self,
-    ui: Ui<'ui>,
+    ui: Ui,
+    ctx: &mut Context,
   ) {
     use imgui::{DrawVert,DrawIdx,DrawCmd,DrawCmdParams};
 
@@ -206,7 +207,7 @@ impl Renderer {
       gl.VertexAttribPointer(self.locs.color,    4, gl::UNSIGNED_BYTE, gl::TRUE,  mem::size_of::<DrawVert>() as _, field_offset::<DrawVert, _, _>(|v| &v.col) as _);
 
 
-      let draw_data = ui.render();
+      let draw_data = ctx.render();
 
       for draw_list in draw_data.draw_lists() {
         let vtx_buffer = draw_list.vtx_buffer();


### PR DESCRIPTION
This patch updates `rust-imgui-opengl-renderer` to work with the recently released `imgui-rs` v0.9.0.

This would probably warrant a breaking semver bump.