### PR TITLE
Bump imgui-rs support to v0.11.x.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /target
 **/*.rs.bk
 Cargo.lock
+/.vs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["gui", "rendering::graphics-api"]
 license = "MIT/Apache-2.0"
 
 [dependencies]
-imgui = ">=0.9.0, <0.10.0"
+imgui = ">=0.9.0, <0.12.0"
 
 [build-dependencies]
 gl_generator = "0.14.0"


### PR DESCRIPTION
Just bumping the used `imgui-rs` dependency in `Cargo.toml`. Planning to bump the version in `rust-imgui-sdl2` should this be approved.